### PR TITLE
Multi sources multi targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,23 +20,80 @@ Sample usage
 This will create a read-only snapshot in /home/snapshot/YYMMDD-HHMMSS,
 and then send it to /backup/YYMMDD-HHMMSS. On future runs, it will
 take a new read-only snapshot and send the difference between the
-previous snapshot (tracked with the symbolic link ".latest") and the
-new one.
+previous snapshot (tracked with a symbolic link named
+".latest.<TARGETNAME>.<SOURCE>") and the new one.
 
 Both source and destination filesystems need to be btrfs volumes. For
 the backup to be sensible, they shouldn't be the same filesystem
 (otherwise, why not just snapshot and save the hassle?).
 
-You can backup multiple volumes to multiple subfolders or subvolumes on the
-destination.  For example, you might want to backup both / and /home.
-The main caveat is you'll want to put the backups in separate folders
-on the destination drive to avoid confusion.
+Local Backup
+------------
 
-    # btrfs-backup.py / /backup/root
-    # btrfs-backup.py /home /backup/home
+You can backup multiple volumes to multiple subfolders or subvolumes
+on the destination.  For example, you might want to backup /boot, /
+and /home, preferred with one btrfs-backup.py call (to get the same
+YYYYMMDD-HHMMSS datetime stamp for snapshots that belong together).
+As the source path is used as part of the snapshot name, snapshots
+from different partitions that belong together can be stored in the
+same directory without troubles.
 
+    # btrfs-backup.py --snapshot /boot/.snapshot --source /boot \
+         --snapshot /mnt/.snapshot/TheHostName --source /mnt/@ \
+         --source /mnt/@home \
+         --backup /backup/snapshot/TheHostName
+
+To support creating snapshots which are stored in different btrfs
+filesystems (here: /boot and /mnt), the --snapshot parameter is used
+to set the snapshot location for all --source parameters that follow.
+
+The above command will create the following snapshots and symlinks:
+
+    /boot/.snapshot/YYYYMMDD-HHMMSS-boot
+    /boot/.snapshot/.latest.local.boot -> YYYYMMDD-HHMMSS-boot
+    /mnt/.snapshot/TheHostName/YYYYMMDD-HHMMSS-@
+    /mnt/.snapshot/TheHostName/YYYYMMDD-HHMMSS-@home
+    /mnt/.snapshot/TheHostName/.latest.local.@ -> YYYYMMDD-HHMMSS-@
+    /mnt/.snapshot/TheHostName/.latest.local.@home -> YYYYMMDD-HHMMSS-@home
+
+Symlinks are named .latest.local.* as no --targetname is specified.
 You can specify the flag --latest-only to only keep the most recent
 snapshot on the source filesystem.
+
+Remote Backup
+-------------
+
+btrfs-backup.py also allows sending the backup to a remote host via a custom
+--remote_backup command:
+
+    # btrfs-backup.py --snapshot /boot/.snapshot --source /boot \
+         --remote_backup "['ssh', 'TheBackupUser@TheBackupHost',
+             'cat > inComing/%DEST%.btrfs-send']" \
+         --snapshot /mnt/.snapshot/TheHostName --source /mnt/@ \
+         --source /mnt/@home \
+         --targetname 'TheBackupHost'
+
+Note that the --remote_backup command expects a python array specifying the
+external command to be run, using "%DEST% as a placeholder for the destination
+snapshot name that shall be created.
+To distinguish the symlinks that are created, the --targetname parameter
+is used, therefore this time the symlinks for keeping track which snapshot
+was sent last to the remote host are named
+
+    /boot/.snapshot/.latest.TheBackupHost.boot -> YYYYMMDD-HHMMSS-boot
+    /mnt/.snapshot/thehostname/.latest.TheBackupHost.@ -> YYYYMMDD-HHMMSS-@
+    /mnt/.snapshot/thehostname/.latest.TheBackupHost.@home -> YYYYMMDD-HHMMSS-@home
+
+On TheBackupHost the btrfs send output is stored in the ~TheBackupUser/inComing
+subdirectory, and can be re-assembled into btrfs snapshots via btrfs receive
+there. By using that indirect approach no root permissions have to be given on
+TheBackupHost to receive the snapshots.
+
+Trial run
+---------
+To just display the (btrfs send, symlink update) commands that would be executed,
+add the --trial parameter. This parameter is nice for setting up without always
+changing symlinks.
 
 Backing up regularly
 ====================
@@ -47,6 +104,7 @@ With anacron on Debian, I simply added a file /etc/cron.daily/local-backup:
     ionice -c 3 /path/to/btrfs-backup.py /home /backup/home
 
 More or less frequent backups could be made using other cron.* scripts.
+
 
 Restoring a snapshot
 ====================

--- a/btrfs-backup.py
+++ b/btrfs-backup.py
@@ -151,6 +151,10 @@ if trial:
     synccmd.insert(0, 'echo')
 subprocess.check_call(synccmd)
 print('Creating snapshot(s) was successful.', file=sys.stderr)
+if backuploc is None:
+    print('No backup location specified, stopping now after creating snapshots.', file=sys.stderr)
+    sys.exit(0)
+
 print('Going to send them to', backuploc, '...', file=sys.stderr)
 # Now we need to send the snapshot (incrementally, if possible), but only those
 # that did not have problems before

--- a/btrfs-backup.py
+++ b/btrfs-backup.py
@@ -217,10 +217,11 @@ for (sourceloc, sourcesnap, snapdir) in snapshots_to_backup:
         elif os.path.exists(latest):
             problems.append('confusion:', latest, "should be a symlink but is not")
             continue
-        # Make .latest point to this backup
+        # Make .latest point to this backup, using local symlink in same directory,
+        # i.e avoid path name in link destination.
         print('New snapshot', sourcesnap, 'created (this is now latest', latest, ').',
               file=sys.stderr)
-        os.symlink(sourcesnap, latest)
+        os.symlink(os.path.basename(sourcesnap), latest)
 
 if len(problems) > 0:
     print("Problem summary:\n * " + "\n * ".join(problems) + 

--- a/btrfs-backup.py
+++ b/btrfs-backup.py
@@ -3,8 +3,8 @@
 # Backup btrfs volume(s) to another, incrementally
 # Requires Python >= 3.3, btrfs-progs >= 3.12 most likely.
 
-# Modifications Copyright (c) 2014 Klaus Holler <kho@gmx.at>
 # Copyright (c) 2014 Chris Lawrence <lawrencc@debian.org>
+# Modifications Copyright (c) 2014-2015 Klaus Holler <kho@gmx.at>
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation files
@@ -33,54 +33,6 @@ import time
 import argparse
 
 start_time = time.localtime()
-print("btrfs-backup started at %s." % time.asctime(start_time))
-
-source_to_snapshot = list()     # for every source remember corresponding snapshot_folder
-class SourceArgAction(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        #print('%r %r %r %r' % (namespace, values, option_string, namespace.snapshot_folder))
-        tup = (values, namespace.snapshot_folder)
-        source_to_snapshot.append(tup)
-
-parser = argparse.ArgumentParser(description="incremental btrfs backup (for multiple "
-                                 " partitions, naming snapshots created together with the "
-                                 " same base datetime stamp)")
-parser.add_argument('--latest-only', action='store_true',
-                    help="only keep latest snapshot on source filesystem")
-parser.add_argument('-d', '--debug', action='store_true',
-                    help="enable btrfs debugging on send/receive")
-parser.add_argument('--snapshot-folder', action='store', default=".snapshot", 
-                    help="snapshot folder in source filesystem")
-parser.add_argument('-t', '--trial', action='store_true',
-		    help="trial run: only show commands that would be executed, but don't run anything")
-# can be used multiple times e.g. -source /boot -source /mnt/@ -source /mnt/@home
-parser.add_argument('-s', '--source', action=SourceArgAction, help="filesystem(s) to backup")
-parser.add_argument('-b', '--backup', help="(local) destination directory to send backups to")
-parser.add_argument('-r', '--remote_backup', help="command to connect/run at destination host, using %DEST% as placeholder for destination snapshot filename (if needed)")
-parser.add_argument('-T', '--targetname', help="name of backup target, useful for creating multiple symlinks that point to the last backed up snapshot per target")
-args = parser.parse_args()
-
-backuploc = args.backup
-trial = args.trial
-targetname = args.targetname
-if args.remote_backup is not None:
-    if type(args.remote_backup) == "<class 'list'>":
-        remote_backup_command = args.remote_backup
-    elif type(args.remote_backup) == type('str'):
-        if args.remote_backup.startswith('['):
-            remote_backup_command = eval(args.remote_backup)
-        else:
-            remote_backup_command = [args.remote_backup]
-    else:
-        raise Exception('Sorry, but type %s of remote_backup is currently not supported' % type(args.remote_backup))
-    print(" remote_backup command: ", remote_backup_command)
-else:
-    remote_backup_command = None
-
-print(" SOURCES: ", source_to_snapshot)
-
-if trial:
-    print("Trial run requested: only show commands that would be executed, but don't run anything")
 
 def datestr(timestamp=None):
     if timestamp is None:
@@ -96,13 +48,15 @@ def new_snapshot(disk, snapshotdir, timestamp=start_time, readonly=True, trial=F
         command += ['-r']
     command += [disk, snaploc]
 
-    subprocess.check_call(command)
-    if os.path.exists(snaploc):
-        return snaploc
-    if trial:
-        return snaploc  # fake success
-    else:
-        return None
+    try:
+        subprocess.check_call(command)
+        if os.path.exists(snaploc):
+            return snaploc
+        if trial:
+            return snaploc  # fake success
+    except CalledProcessError:
+        print("Error on command:", str(command), file=sys.stderr)
+    return None
 
 def send_snapshot(srcloc, destloc, prevsnapshot=None, debug=False, trial=False,
                   remote_backup_command=None):
@@ -135,97 +89,214 @@ def send_snapshot(srcloc, destloc, prevsnapshot=None, debug=False, trial=False,
     #print(pipe.returncode, file=sys.stderr)
     return pipe.returncode
 
-def delete_snapshot(snaploc):
+def find_old_backup(bak_dir_time_objs,recurse_val = 0):
+    """ Find oldest time object in "bak_dir_time_objs" structure.
+        recurse_val = 0 -> start with top entry "year", default
+    """
+    tmp = []
+    for timeobj in bak_dir_time_objs:
+        tmp.append(timeobj[recurse_val])
+
+    min_val = min(tmp) # find minimum time value
+    new_timeobj = []
+
+    for timeobj in bak_dir_time_objs:
+        if(timeobj[recurse_val] == min_val):
+            new_timeobj.append(timeobj)
+
+    if (len(new_timeobj) > 1):
+        return find_old_backup(new_timeobj,recurse_val+1) # recursive call from year to minute
+    else:
+        return new_timeobj[0]
+
+def delete_old_backups(backuploc, source_postfix, max_num_backups, trial):
+    """ Delete old backup directories in backup target folder based on their date.
+        Warning: This function will delete btrfs snapshots in target folder based on
+        the parameter max_num_backups!
+    """
+    # As snapshots of different partitions/mountpoints can be stored in the same
+    # directory now, have to filter only those that match the current source (postfix).
+    # recurse target backup folder until "max_num_backups" is reached
+    backups_of_source = [d for d in os.listdir(backuploc)
+                            if d.endswith(source_postfix)]
+    print(backups_of_source)
+    cur_num_backups = len(backups_of_source)
+    for i in range(cur_num_backups - max_num_backups):
+        # find all backup snapshots in directory and build time object list
+        bak_dir_time_objs = []
+        backups_of_source = [d for d in os.listdir(backuploc)
+                                if d.endswith(source_postfix)]
+        for directory in backups_of_source:
+            timestamp = re.sub(source_postfix, '', directory)
+            bak_dir_time_objs.append(time.strptime(timestamp, '%Y%m%d-%H%M%S'))
+
+        # find oldest directory object and mark to remove
+        bak_dir_to_rm = datestr(find_old_backup(bak_dir_time_objs, 0)) + source_postfix
+        bak_dir_to_rm_path = os.path.join(backuploc, bak_dir_to_rm)
+        print ("Removing old backup dir " + bak_dir_to_rm_path)
+        # delete snapshot of oldest backup snapshot
+        delete_snapshot(bak_dir_to_rm_path, trial)
+
+def delete_snapshot(snaploc, trial=False):
     delcmd = ['btrfs', 'subvolume', 'delete', snaploc]
     if trial:
         delcmd.insert(0, 'echo')
+    delcmd.insert(0, 'echo')    # make sure that during testing snapshots are not deleted
     subprocess.check_output(delcmd)
 
+if __name__ == "__main__":
+    print("btrfs-backup started at %s." % time.asctime(start_time))
 
-# First we need to create a new snapshot on the source disk(s) for all sources
-snapshots_to_backup = list()
-problems = list()
-for (sourceloc, snapdir) in source_to_snapshot:
-    # Ensure snapshot directory exists
-    if not os.path.exists(snapdir):
-        problems.append("Snapshot base path %r for source %r does not exist, source skipped." % \
-            (snapdir, sourceloc))
-        continue
-    sourcesnap = new_snapshot(sourceloc, snapdir, trial=trial)
-    if not sourcesnap:
-        problems.append("snapshot for %r to %r failed" % (sourceloc, snapdir))
+    source_to_snapshot = list()     # for every source remember corresponding snapshot_folder
+    class SourceArgAction(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            #print('%r %r %r %r' % (namespace, values, option_string, namespace.snapshot_folder))
+            tup = (values, namespace.snapshot_folder)
+            source_to_snapshot.append(tup)
+
+    parser = argparse.ArgumentParser(description="incremental btrfs backup (for multiple "
+                                     " partitions, naming snapshots created together with the "
+                                     " same base datetime stamp)")
+    parser.add_argument('--latest-only', action='store_true',
+                        help="only keep latest snapshot on source filesystem")
+    parser.add_argument('-d', '--debug', action='store_true',
+                        help="enable btrfs debugging on send/receive")
+    parser.add_argument('--num-backups', type=int, default=0,
+                        help="only store given number of backups in backup folder")
+    parser.add_argument('--snapshot-folder', action='store', default=".snapshot",
+                        help="snapshot folder in source filesystem")
+    parser.add_argument('-t', '--trial', action='store_true',
+                help="trial run: only show commands that would be executed, but don't run anything")
+    # can be used multiple times e.g. -source /boot -source /mnt/@ -source /mnt/@home
+    parser.add_argument('-s', '--source', action=SourceArgAction, help="filesystem(s) to backup")
+    parser.add_argument('-b', '--backup', help="(local) destination directory to send backups to")
+    parser.add_argument('-r', '--remote_backup', help="command to connect/run at destination host, using %DEST% as placeholder for destination snapshot filename (if needed)")
+    parser.add_argument('-T', '--targetname', help="name of backup target, useful for creating multiple symlinks that point to the last backed up snapshot per target")
+    args = parser.parse_args()
+
+    backuploc = args.backup
+    NUM_BACKUPS = args.num_backups
+    print("Num backups:", NUM_BACKUPS, file=sys.stderr)
+
+    trial = args.trial
+
+    if (NUM_BACKUPS > 0):
+        delete_old_backups(backuploc,NUM_BACKUPS)
+        sys.exit(1)     # indicate success
+
+    targetname = args.targetname
+    if args.remote_backup is not None:
+        if type(args.remote_backup) == "<class 'list'>":
+            remote_backup_command = args.remote_backup
+        elif type(args.remote_backup) == type('str'):
+            if args.remote_backup.startswith('['):
+                remote_backup_command = eval(args.remote_backup)
+            else:
+                remote_backup_command = [args.remote_backup]
+        else:
+            raise Exception('Sorry, but type %s of remote_backup is currently not supported' % type(args.remote_backup))
+        print(" remote_backup command: ", remote_backup_command)
     else:
-        snapshots_to_backup.append((sourceloc, sourcesnap, snapdir))
+        remote_backup_command = None
 
-if len(problems) > 0:
-    if trial: 
-        print("Trial: ignoring problems encountered while creating snapshots:\n * " + \
-              "\n * ".join(problems), file=sys.stderr)
-    else:
-        print("Problems encountered while creating snapshots:\n * " + \
-              "\n * ".join(problems), file=sys.stderr)
-        sys.exit(1)
+    print(" SOURCES: ", source_to_snapshot)
 
-# Need to sync
-synccmd = ['sync']
-if trial:
-    synccmd.insert(0, 'echo')
-subprocess.check_call(synccmd)
-print('Creating snapshot(s) was successful.', file=sys.stderr)
-if (backuploc is None) and (remote_backup_command is None):
-    print('Neither local backup location nor remote backup command specified, stopping now after creating snapshots.', file=sys.stderr)
-    sys.exit(0)
-
-if backuploc is None:
-    print('Going to send them via remote backup command:', " ".join(remote_backup_command), 
-          '...', file=sys.stderr)
-    if targetname is None:
-        targetname = 'remote'
-else:
-    print('Going to send them to', backuploc, '...', file=sys.stderr)
-    if targetname is None:
-        targetname = 'local'
-# Now we need to send the snapshot (incrementally, if possible), but only those
-# that did not have problems before
-for (sourceloc, sourcesnap, snapdir) in snapshots_to_backup:
-    latest = os.path.join(snapdir, '.latest.' + targetname + '.' + os.path.basename(sourceloc))
-    real_latest = os.path.realpath(latest)
     if trial:
-        print("trial: searching realpath of latest symlink %r for source %r" % (latest, sourceloc))
-    else:
-        print("searching realpath of latest symlink %r for source %r" % (real_latest, sourceloc))
-    if os.path.exists(real_latest):
-        print('sending incremental backup from', sourcesnap,
-            'to', backuploc, 'using base', real_latest, file=sys.stderr)
-        send_snapshot(sourcesnap, backuploc, real_latest, debug=args.debug, trial=trial,
-                      remote_backup_command=remote_backup_command)
-        if args.latest_only:
-            print('removing old snapshot', real_latest, file=sys.stderr)
-            delete_snapshot(real_latest)
-    else:
-        print('initial snapshot successful; sending full backup from', sourcesnap,
-            'to', backuploc, file=sys.stderr)
-        send_snapshot(sourcesnap, backuploc, debug=args.debug, trial=trial,
-                      remote_backup_command=remote_backup_command)
-    if trial:
-        print("trial: would change latest link %r to point to %r" % (latest, sourcesnap))
-    else:
-        print("changing latest link %r to point to %r" % (latest, sourcesnap))
-        if os.path.islink(latest):
-            print("unlinking %r" % latest)
-            os.unlink(latest)
-        elif os.path.exists(latest):
-            problems.append('confusion:', latest, "should be a symlink but is not")
+        print("Trial run requested: only show commands that would be executed, but don't run anything")
+
+    # First we need to create a new snapshot on the source disk(s) for all sources
+    snapshots_to_backup = list()
+    problems = list()
+    for (sourceloc, snapdir) in source_to_snapshot:
+        # Ensure snapshot directory exists
+        # TODO: test if the source is a subvolume, it should be and this should be tested.
+        if not os.path.exists(snapdir):
+            problems.append("Snapshot base path %r for source %r does not exist, source skipped." % \
+                (snapdir, sourceloc))
             continue
-        # Make .latest point to this backup, using local symlink in same directory,
-        # i.e avoid path name in link destination.
-        print('New snapshot', sourcesnap, 'created (this is now latest', latest, ').',
-              file=sys.stderr)
-        os.symlink(os.path.basename(sourcesnap), latest)
+        sourcesnap = new_snapshot(sourceloc, snapdir, trial=trial)
+        if not sourcesnap:
+            problems.append("snapshot for %r to %r failed" % (sourceloc, snapdir))
+        else:
+            snapshots_to_backup.append((sourceloc, sourcesnap, snapdir))
 
-if len(problems) > 0:
-    print("Problem summary:\n * " + "\n * ".join(problems) + 
-          "\nBackup might be incomplete.", file=sys.stderr)
-    sys.exit(1) # indicate failure
-print('Backup complete.', file=sys.stderr)
-sys.exit(0)     # indicate success
+    if len(problems) > 0:
+        if trial:
+            print("Trial: ignoring problems encountered while creating snapshots:\n * " + \
+                  "\n * ".join(problems), file=sys.stderr)
+        else:
+            print("Problems encountered while creating snapshots:\n * " + \
+                  "\n * ".join(problems), file=sys.stderr)
+            sys.exit(1)
+
+    # Need to sync
+    synccmd = ['sync']
+    if trial:
+        synccmd.insert(0, 'echo')
+    subprocess.check_call(synccmd)
+    print('Creating snapshot(s) was successful.', file=sys.stderr)
+    if (backuploc is None) and (remote_backup_command is None):
+        print('Neither local backup location nor remote backup command specified, stopping now after creating snapshots.', file=sys.stderr)
+        sys.exit(0)
+
+    if backuploc is None:
+        print('Going to send them via remote backup command:',
+              " ".join(remote_backup_command), '...', file=sys.stderr)
+        if targetname is None:
+            targetname = 'remote'
+    else:
+        print('Going to send them to', backuploc, '...', file=sys.stderr)
+        # TODO: include a test if the destination is a subvolume. It should be and this should be tested.
+        if targetname is None:
+            targetname = 'local'
+    # Now we need to send the snapshot (incrementally, if possible), but only those
+    # that did not have problems before
+    for (sourceloc, sourcesnap, snapdir) in snapshots_to_backup:
+        latest = os.path.join(snapdir, '.latest.' + targetname + '.' +
+                              os.path.basename(sourceloc))
+        real_latest = os.path.realpath(latest)
+        if trial:
+            print("trial: searching realpath of latest symlink %r for source %r" % (latest, sourceloc))
+        else:
+            print("searching realpath of latest symlink %r for source %r" % (real_latest, sourceloc))
+        if os.path.exists(real_latest):
+            print('sending incremental backup from', sourcesnap,
+                'to', backuploc, 'using base', real_latest, file=sys.stderr)
+            send_snapshot(sourcesnap, backuploc, real_latest, debug=args.debug, trial=trial,
+                          remote_backup_command=remote_backup_command)
+            if args.latest_only:
+                print('removing old snapshot', real_latest, file=sys.stderr)
+                delete_snapshot(real_latest, trial)
+        else:
+            print('initial snapshot successful; sending full backup from', sourcesnap,
+                'to', backuploc, file=sys.stderr)
+            send_snapshot(sourcesnap, backuploc, debug=args.debug, trial=trial,
+                          remote_backup_command=remote_backup_command)
+        if trial:
+            print("trial: would change latest link %r to point to %r" % (latest, sourcesnap))
+        else:
+            print("changing latest link %r to point to %r" % (latest, sourcesnap))
+            if os.path.islink(latest):
+                print("unlinking %r" % latest)
+                os.unlink(latest)
+            elif os.path.exists(latest):
+                problems.append('confusion:', latest, "should be a symlink but is not")
+                continue
+            # Make .latest point to this backup, using local symlink in same directory,
+            # i.e avoid path name in link destination.
+            print('New snapshot', sourcesnap, 'created (this is now latest', latest, ').',
+                  file=sys.stderr)
+            os.symlink(os.path.basename(sourcesnap), latest)
+
+    if len(problems) > 0:
+        print("Problem summary:\n * " + "\n * ".join(problems) +
+              "\nBackup might be incomplete.", file=sys.stderr)
+        sys.exit(1) # indicate failure
+    print('Backup complete.', file=sys.stderr)
+
+    # cleanup backups > NUM_BACKUPS in backup target
+    if (NUM_BACKUPS > 0):
+        for (sourceloc, sourcesnap, snapdir) in snapshots_to_backup:
+            delete_old_backups(backuploc, sourceloc, NUM_BACKUPS, trial)
+
+    sys.exit(0)     # indicate success

--- a/btrfs-backup.py
+++ b/btrfs-backup.py
@@ -74,7 +74,8 @@ def send_snapshot(srcloc, destloc, prevsnapshot=None, debug=False, trial=False,
 
     if remote_backup_command is not None:
         # custom remote backup command instead of normal btrfs receive %DEST%
-        destcmd = [it.replace("%DEST%", os.path.basename(srcloc)) for it in remote_backup_command]
+        destcmd = [it.replace("%DEST%", os.path.basename(srcloc)) 
+            for it in remote_backup_command]
     else:
         destcmd = ['btrfs', 'receive'] + flags + [destloc]
     if trial:
@@ -119,7 +120,8 @@ def delete_old_backups(backuploc, source, max_num_backups, trial):
             time_to_backupname[t_backup] = d_fullpath
 
     num_backups = len(time_to_backupname)
-    print("%d backups found matching '%s/YYYYMMDD-HHMMSS-%s'" % (num_backups, backuploc, source))
+    print("%d backups found matching '%s/YYYYMMDD-HHMMSS-%s'" % \
+          (num_backups, backuploc, source))
     for t_backup in sorted(time_to_backupname.keys()):
         backup_path = time_to_backupname[t_backup]
         if num_backups < max_num_backups:
@@ -132,16 +134,15 @@ def delete_old_backups(backuploc, source, max_num_backups, trial):
 if __name__ == "__main__":
     print("btrfs-backup started at %s." % time.asctime(start_time))
 
-    source_to_snapshot = list()     # for every source remember corresponding snapshot_folder
+    source_to_snapshot = list()  # for every source remember corresponding snapshot_folder
     class SourceArgAction(argparse.Action):
         def __call__(self, parser, namespace, values, option_string=None):
-            #print('%r %r %r %r' % (namespace, values, option_string, namespace.snapshot_folder))
             tup = (values, namespace.snapshot_folder)
             source_to_snapshot.append(tup)
 
-    parser = argparse.ArgumentParser(description="incremental btrfs backup (for multiple "
-                                     " partitions, naming snapshots created together with the "
-                                     " same base datetime stamp)")
+    parser = argparse.ArgumentParser(description="incremental btrfs backup (for "
+        " multiple partitions, naming snapshots created together with the same "
+        " base datetime stamp)")
     parser.add_argument('--latest-only', action='store_true',
                         help="only keep latest snapshot on source filesystem")
     parser.add_argument('-d', '--debug', action='store_true',
@@ -151,12 +152,18 @@ if __name__ == "__main__":
     parser.add_argument('--snapshot-folder', action='store', default=".snapshot",
                         help="snapshot folder in source filesystem")
     parser.add_argument('-t', '--trial', action='store_true',
-                help="trial run: only show commands that would be executed, but don't run anything")
+        help="trial run: only show commands that would be executed, but don't run them")
     # can be used multiple times e.g. -source /boot -source /mnt/@ -source /mnt/@home
-    parser.add_argument('-s', '--source', action=SourceArgAction, help="filesystem(s) to backup")
-    parser.add_argument('-b', '--backup', help="(local) destination directory to send backups to")
-    parser.add_argument('-r', '--remote_backup', help="command to connect/run at destination host, using %DEST% as placeholder for destination snapshot filename (if needed)")
-    parser.add_argument('-T', '--targetname', help="name of backup target, useful for creating multiple symlinks that point to the last backed up snapshot per target")
+    parser.add_argument('-s', '--source', action=SourceArgAction, 
+        help="filesystem(s) to backup")
+    parser.add_argument('-b', '--backup', help="(local) destination directory to "
+        "send backups to")
+    parser.add_argument('-r', '--remote_backup', help="command to connect/run at "
+        "destination host, using %DEST% as placeholder for destination snapshot "
+        "filename (if needed)")
+    parser.add_argument('-T', '--targetname', help="name of backup target, useful "
+        "for creating multiple symlinks that point to the last backed up snapshot "
+        "per target")
     args = parser.parse_args()
 
     backuploc = args.backup
@@ -179,7 +186,8 @@ if __name__ == "__main__":
             else:
                 remote_backup_command = [args.remote_backup]
         else:
-            raise Exception('Sorry, but type %s of remote_backup is currently not supported' % type(args.remote_backup))
+            raise Exception('Sorry, but type %s of remote_backup is currently "
+                "not supported' % type(args.remote_backup))
         print(" remote_backup command: ", remote_backup_command)
     else:
         remote_backup_command = None
@@ -187,7 +195,8 @@ if __name__ == "__main__":
     print(" SOURCES: ", source_to_snapshot)
 
     if trial:
-        print("Trial run requested: only show commands that would be executed, but don't run anything")
+        print("Trial run requested: only show commands that would be executed, but "
+            "don't run anything")
 
     # First we need to create a new snapshot on the source disk(s) for all sources
     snapshots_to_backup = list()
@@ -196,8 +205,8 @@ if __name__ == "__main__":
         # Ensure snapshot directory exists
         # TODO: test if the source is a subvolume, it should be and this should be tested.
         if not os.path.exists(snapdir):
-            problems.append("Snapshot base path %r for source %r does not exist, source skipped." % \
-                (snapdir, sourceloc))
+            problems.append("Snapshot base path %r for source %r does not exist, "
+                "source skipped." % (snapdir, sourceloc))
             continue
         sourcesnap = new_snapshot(sourceloc, snapdir, trial=trial)
         if not sourcesnap:
@@ -207,8 +216,8 @@ if __name__ == "__main__":
 
     if len(problems) > 0:
         if trial:
-            print("Trial: ignoring problems encountered while creating snapshots:\n * " + \
-                  "\n * ".join(problems), file=sys.stderr)
+            print("Trial: ignoring problems encountered while creating snapshots:"
+                "\n * " + "\n * ".join(problems), file=sys.stderr)
         else:
             print("Problems encountered while creating snapshots:\n * " + \
                   "\n * ".join(problems), file=sys.stderr)
@@ -221,7 +230,8 @@ if __name__ == "__main__":
     subprocess.check_call(synccmd)
     print('Creating snapshot(s) was successful.', file=sys.stderr)
     if (backuploc is None) and (remote_backup_command is None):
-        print('Neither local backup location nor remote backup command specified, stopping now after creating snapshots.', file=sys.stderr)
+        print('Neither local backup location nor remote backup command specified, "
+            "stopping now after creating snapshots.', file=sys.stderr)
         sys.exit(0)
 
     if backuploc is None:
@@ -241,14 +251,16 @@ if __name__ == "__main__":
                               os.path.basename(sourceloc))
         real_latest = os.path.realpath(latest)
         if trial:
-            print("trial: searching realpath of latest symlink %r for source %r" % (latest, sourceloc))
+            print("trial: searching realpath of latest symlink %r for source %r" % \
+                  (latest, sourceloc))
         else:
-            print("searching realpath of latest symlink %r for source %r" % (real_latest, sourceloc))
+            print("searching realpath of latest symlink %r for source %r" % \
+                  (real_latest, sourceloc))
         if os.path.exists(real_latest):
             print('sending incremental backup from', sourcesnap,
                 'to', backuploc, 'using base', real_latest, file=sys.stderr)
-            send_snapshot(sourcesnap, backuploc, real_latest, debug=args.debug, trial=trial,
-                          remote_backup_command=remote_backup_command)
+            send_snapshot(sourcesnap, backuploc, real_latest, debug=args.debug,
+                trial=trial, remote_backup_command=remote_backup_command)
             if args.latest_only:
                 print('removing old snapshot', real_latest, file=sys.stderr)
                 delete_snapshot(real_latest, trial)
@@ -258,7 +270,8 @@ if __name__ == "__main__":
             send_snapshot(sourcesnap, backuploc, debug=args.debug, trial=trial,
                           remote_backup_command=remote_backup_command)
         if trial:
-            print("trial: would change latest link %r to point to %r" % (latest, sourcesnap))
+            print("trial: would change latest link %r to point to %r" % \
+                  (latest, sourcesnap))
         else:
             print("changing latest link %r to point to %r" % (latest, sourcesnap))
             if os.path.islink(latest):

--- a/btrfs-backup.py
+++ b/btrfs-backup.py
@@ -130,7 +130,7 @@ for (sourceloc, snapdir) in source_to_snapshot:
         problems.append("Snapshot base path %r for source %r does not exist, source skipped." % \
             (snapdir, sourceloc))
         continue
-    sourcesnap = new_snapshot(sourceloc, snapdir)
+    sourcesnap = new_snapshot(sourceloc, snapdir, trial=trial)
     if not sourcesnap:
         problems.append("snapshot for %r to %r failed" % (sourceloc, snapdir))
     else:
@@ -168,14 +168,14 @@ for (sourceloc, sourcesnap, snapdir) in snapshots_to_backup:
     if os.path.exists(real_latest):
         print('sending incremental backup from', sourcesnap,
             'to', backuploc, 'using base', real_latest, file=sys.stderr)
-        send_snapshot(sourcesnap, backuploc, real_latest, debug=args.debug)
+        send_snapshot(sourcesnap, backuploc, real_latest, debug=args.debug, trial=trial)
         if args.latest_only:
             print('removing old snapshot', real_latest, file=sys.stderr)
             delete_snapshot(real_latest)
     else:
         print('initial snapshot successful; sending full backup from', sourcesnap,
             'to', backuploc, file=sys.stderr)
-        send_snapshot(sourcesnap, backuploc, debug=args.debug)
+        send_snapshot(sourcesnap, backuploc, debug=args.debug, trial=trial)
     if trial:
         print("trial: would change latest link %r to point to %r" % (latest, sourcesnap))
     else:

--- a/btrfs-backup.py
+++ b/btrfs-backup.py
@@ -48,7 +48,7 @@ backuploc = args.backup
 if args.snapshot_folder:
     SNAPSHOTDIR = args.snapshot_folder
 else:
-    SNAPSHOTDIR = 'snapshot'
+    SNAPSHOTDIR = '.snapshot'
 
 LASTNAME = os.path.join(SNAPSHOTDIR, '.latest')
 
@@ -83,8 +83,8 @@ def send_snapshot(srcloc, destloc, prevsnapshot=None, debug=False):
 
     destcmd = ['btrfs', 'receive'] + flags + [destloc]
 
-    #print(srccmd)
-    #print(destcmd)
+    print(srccmd)
+    print(destcmd)
 
     pipe = subprocess.Popen(srccmd, stdout=subprocess.PIPE)
     output = subprocess.check_output(destcmd, stdin=pipe.stdout)

--- a/btrfs-backup.py
+++ b/btrfs-backup.py
@@ -113,7 +113,7 @@ def delete_old_backups(backuploc, source, max_num_backups, trial):
             timestr = m.group('time')
             t_backup = time.strptime(timestr, '%Y%m%d-%H%M%S')
             if t_backup in time_to_backupname:
-                raise Exception("Backup time '%s' occurs twice while searching for "
+                raise Exception("Backup time '%s' occurs twice while searching for " \
                     "old backups to delete, this is forbidden: %s and %s" % \
                     (timestr, os.path.join(backuploc,time_to_backupname[t_backup]),
                     d_fullpath))
@@ -186,7 +186,7 @@ if __name__ == "__main__":
             else:
                 remote_backup_command = [args.remote_backup]
         else:
-            raise Exception('Sorry, but type %s of remote_backup is currently "
+            raise Exception('Sorry, but type %s of remote_backup is currently " \
                 "not supported' % type(args.remote_backup))
         print(" remote_backup command: ", remote_backup_command)
     else:
@@ -230,7 +230,7 @@ if __name__ == "__main__":
     subprocess.check_call(synccmd)
     print('Creating snapshot(s) was successful.', file=sys.stderr)
     if (backuploc is None) and (remote_backup_command is None):
-        print('Neither local backup location nor remote backup command specified, "
+        print('Neither local backup location nor remote backup command specified, " \
             "stopping now after creating snapshots.', file=sys.stderr)
         sys.exit(0)
 

--- a/btrfs-backup.py
+++ b/btrfs-backup.py
@@ -63,19 +63,21 @@ args = parser.parse_args()
 backuploc = args.backup
 trial = args.trial
 targetname = args.targetname
-if type(args.remote_backup) == "<class 'list'>":
-    remote_backup_command = args.remote_backup
-elif type(args.remote_backup) == type('str'):
-    if args.remote_backup.startswith('['):
-        remote_backup_command = eval(args.remote_backup)
+if args.remote_backup is not None:
+    if type(args.remote_backup) == "<class 'list'>":
+        remote_backup_command = args.remote_backup
+    elif type(args.remote_backup) == type('str'):
+        if args.remote_backup.startswith('['):
+            remote_backup_command = eval(args.remote_backup)
+        else:
+            remote_backup_command = [args.remote_backup]
     else:
-        remote_backup_command = [args.remote_backup]
+        raise Exception('Sorry, but type %s of remote_backup is currently not supported' % type(args.remote_backup))
+    print(" remote_backup command: ", remote_backup_command)
 else:
-    raise Exception('Sorry, but type %s of remote_backup is currently not supported' % type(args.remote_backup))
+    remote_backup_command = None
 
 print(" SOURCES: ", source_to_snapshot)
-if remote_backup_command is not None:
-    print(" remote_backup command: ", remote_backup_command)
 
 if trial:
     print("Trial run requested: only show commands that would be executed, but don't run anything")

--- a/btrfs-backup.py
+++ b/btrfs-backup.py
@@ -182,14 +182,14 @@ for (sourceloc, sourcesnap, snapdir) in snapshots_to_backup:
         print("changing latest link %r to point to %r" % (latest, sourcesnap))
         if os.path.islink(latest):
             print("unlinking %r" % latest)
-            #os.unlink(latest)
+            os.unlink(latest)
         elif os.path.exists(latest):
             problems.append('confusion:', latest, "should be a symlink but is not")
             continue
         # Make .latest point to this backup
         print('New snapshot', sourcesnap, 'created (this is now latest', latest, ').',
               file=sys.stderr)
-        #os.symlink(sourcesnap, latest)
+        os.symlink(sourcesnap, latest)
 
 if len(problems) > 0:
     print("Problem summary:\n * " + "\n * ".join(problems) + 


### PR DESCRIPTION
Hello,

I've enhanced the btrfs-backup.py script to be able to
1.) store multiple backups (which belong together) in one directory,
2.) support tracking multiple backup destination/target directories,
3.) send a snapshot with a user-specified command (e.g. ssh call) to a remote host - see --remote_backup parameter and 'Remote Backup' intro in README.md.
4.) To not do anything but just show what whould be done, I added a '--trial' option

ad 1.) typically, I have one directory per host in which all the snapshots for that host end up, for distinction between the snapshots, the source name is postfixed to the created snapshot-name YYYYMMDD-HHMMSS-sourcename (see README.md example I added)

ad 2.) I do backups to a NAS and to external HDDs, to track the last states I had to extend/change the naming scheme to use .latest.<TARGETNAME>.<SOURCE> - adding <TARGETNAME> to distinguish between target locations, and adding <SOURCE> to distinguish between different snapshots of one host which end up in the same directory (see 1.).

Kind regards,
Klaus
